### PR TITLE
Update UIWindow.js to permit Safari to store cookies for embedded apps

### DIFF
--- a/src/UI/UIWindow.js
+++ b/src/UI/UIWindow.js
@@ -296,7 +296,7 @@ async function UIWindow(options) {
                         ${options.iframe_url ? 'src="'+ html_encode(options.iframe_url)+'"' : ''}
                         ${options.iframe_srcdoc ? 'srcdoc="'+ html_encode(options.iframe_srcdoc) +'"' : ''}
                         allow = "accelerometer; camera; encrypted-media; gamepad; display-capture; geolocation; gyroscope; microphone; midi; clipboard-read; clipboard-write; web-share; fullscreen;"
-                        sandbox="allow-forms allow-modals allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation allow-downloads allow-presentation"></iframe>`;
+                        sandbox="allow-forms allow-modals allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation allow-downloads allow-presentation allow-storage-access-by-user-activation"></iframe>`;
             }
             // custom body
             else if(options.body_content !== undefined){


### PR DESCRIPTION
Adding `allow-storage-access-by-user-activation` which is important for permitting Safari to ask the user if the embedded app can use cookies, which enhances security, privacy and user consent.

See here for more discussion: https://github.com/HeyPuter/puter/issues/143#issuecomment-2008692100